### PR TITLE
Clarify readiness steps for Firebase deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-cu'r# Firebase Studio
+# Firebase Studio
 
-This is a NextJS starter in Firebase Studio.
+This is a Next.js starter in Firebase Studio.
 
-To get started, take a look at src/app/page.tsx.
+To get started, take a look at `src/app/page.tsx`.
+
+## Deploying with Firebase
+
+The project is already configured for Firebase App Hosting. Follow the steps in
+[`docs/firebase-deploy.md`](docs/firebase-deploy.md) to publish the site with the
+Firebase CLI.

--- a/docs/firebase-deploy.md
+++ b/docs/firebase-deploy.md
@@ -1,0 +1,77 @@
+# Deploying to Firebase App Hosting
+
+This project is configured to deploy the Next.js frontend and any associated Firebase services through **Firebase App Hosting**. Follow the steps below to publish the site.
+
+> **Quick checklist**
+>
+> 1. You can build the app locally with `npm run build`.
+> 2. The Firebase CLI is installed and you are signed in to the correct project.
+> 3. Any required environment secrets are configured in App Hosting.
+>
+> If every item above is true, you're ready to deploy with the command in [Step&nbsp;4](#4-deploy-the-application).
+
+## 1. Install the Firebase CLI
+
+```bash
+npm install -g firebase-tools
+```
+
+Confirm the installation:
+
+```bash
+firebase --version
+```
+
+## 2. Authenticate and select your project
+
+Log in to Firebase and choose the project you want to use. If you already have a Firebase project, replace `<project-id>` with its ID. If you need to create a project, do so from the [Firebase console](https://console.firebase.google.com/) first.
+
+If you are unsure which project to target, list the projects that are available to your account:
+
+```bash
+firebase projects:list
+```
+
+```bash
+firebase login
+firebase use --add <project-id>
+```
+
+## 3. Configure required environment secrets (optional)
+
+If your app relies on environment variables, set them up as [App Hosting secrets](https://firebase.google.com/docs/app-hosting/environment-variables) so that they are available during build and runtime:
+
+```bash
+firebase apphosting:secrets:set <SECRET_NAME>
+```
+
+Repeat for each secret, following the prompts to provide the values. You can review existing secrets with:
+
+```bash
+firebase apphosting:secrets:list
+```
+
+## 4. Deploy the application
+
+App Hosting automatically runs the production build for your Next.js app. If you want to double-check the build locally, run `npm run build` once before deploying. Then deploy using:
+
+```bash
+firebase deploy --only apphosting
+```
+
+To deploy Firestore security rules, indexes, or Cloud Functions alongside the app, include them in the `--only` flag, for example:
+
+```bash
+firebase deploy --only apphosting,firestore,functions
+```
+
+## 5. Verify the deployment
+
+Once the command completes, the CLI outputs the hosting URL. Open it in your browser to confirm that the site is live. You can manage subsequent deployments with the same `firebase deploy --only apphosting` command whenever changes are ready to publish.
+
+## Troubleshooting tips
+
+- Run `firebase logout` and `firebase login` if you encounter authentication errors.
+- Ensure your local Node.js version matches the requirement in `package.json` (`>=20.18.0`).
+- Use `firebase deploy --only apphosting --debug` for verbose logs when debugging deployment issues.
+


### PR DESCRIPTION
## Summary
- add a quick readiness checklist to the Firebase App Hosting guide
- document how to verify the targeted Firebase project before deploying
- remind contributors to confirm the Next.js build locally when desired

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d748ec8a50832b8b7fd8700ad6af30