### PR TITLE
Fix GitHub Actions deploy for Firebase App Hosting

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Hosting (Next.js)
+name: Deploy to Firebase App Hosting (Next.js)
 
 on:
   push:
@@ -11,10 +11,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-
-    env:
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-      FIREBASE_SITE_ID: ${{ secrets.FIREBASE_SITE_ID }}
 
     steps:
       - name: Checkout
@@ -34,13 +30,16 @@ jobs:
         # 如果你是纯静态导出，改用：
         # run: npm run export
 
-      - name: Deploy to Firebase Hosting (live)
-        uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          channelId: live
-          projectId: ${{ env.FIREBASE_PROJECT_ID }}
-          target: ${{ env.FIREBASE_SITE_ID }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          # 如果你坚持用 token（login:ci）部署，就把上一行注释，改用：
-          # token: ${{ secrets.FIREBASE_TOKEN }}
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase App Hosting (live)
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          firebase deploy --only apphosting --project "$FIREBASE_PROJECT_ID"


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to deploy with `firebase deploy --only apphosting`
- authenticate via the Google auth action and reuse the service account secret
- install the Firebase CLI in CI for the deployment step

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7c119866c832b9f48ae2dc31a1228