### PR TITLE
Ensure homepage loads real public creations

### DIFF
--- a/src/features/creations/server/actions.ts
+++ b/src/features/creations/server/actions.ts
@@ -26,8 +26,6 @@ import {
   type ToggleModelVisibilityInput,
 } from './creation-service';
 import { isFirebaseAdminConfigured } from '@/server/firebase/admin';
-import { MOCK_PUBLIC_CREATIONS, MOCK_TRENDING_CREATIONS } from '@/lib/mock-data';
-import type { Creation } from '@/lib/types';
 
 const ensureFirestore = () => {
   if (!isFirebaseAdminConfigured()) {
@@ -124,12 +122,7 @@ export const logCreationInteractionAction = async (input: LogInteractionInput) =
 };
 
 export const getPersonalizedFeedsAction = async (userId: string | null) => {
-  if (!isFirebaseAdminConfigured()) {
-    return {
-      popular: MOCK_PUBLIC_CREATIONS,
-      trending: MOCK_TRENDING_CREATIONS,
-    } satisfies { popular: Creation[]; trending: Creation[] };
-  }
+  ensureFirestore();
   return getPersonalizedFeeds(userId);
 };
 
@@ -152,16 +145,12 @@ export const toggleCreationPublicStatusAction = async (creationId: string, isPub
 };
 
 export const getPublicCreationsAction = async () => {
-  if (!isFirebaseAdminConfigured()) {
-    return MOCK_PUBLIC_CREATIONS;
-  }
+  ensureFirestore();
   return getPublicCreations();
 };
 
 export const getTrendingCreationsAction = async () => {
-  if (!isFirebaseAdminConfigured()) {
-    return MOCK_TRENDING_CREATIONS;
-  }
+  ensureFirestore();
   return getTrendingCreations();
 };
 

--- a/src/features/creations/server/creation-service.ts
+++ b/src/features/creations/server/creation-service.ts
@@ -14,7 +14,6 @@ import type {
   CreationData,
   Model,
 } from '@/lib/types';
-import { MOCK_PUBLIC_CREATIONS, MOCK_TRENDING_CREATIONS } from '@/lib/mock-data';
 import { admin, getAdminStorage } from '@/server/firebase/admin';
 import { logger } from '@/utils/logger';
 import {
@@ -391,10 +390,11 @@ export const logInteraction = async ({
 
 export const getPersonalizedFeeds = async (userId: string | null) => {
   const creations = await listPublicCreations();
+
   if (!creations.length) {
     return {
-      popular: MOCK_PUBLIC_CREATIONS,
-      trending: MOCK_TRENDING_CREATIONS,
+      popular: [],
+      trending: [],
     };
   }
 
@@ -441,17 +441,11 @@ export const toggleCreationPublicStatus = async (creationId: string, isPublic: b
 
 export const getPublicCreations = async (): Promise<Creation[]> => {
   const creations = await listPublicCreations();
-  if (!creations.length) {
-    return MOCK_PUBLIC_CREATIONS;
-  }
   return creations;
 };
 
 export const getTrendingCreations = async (): Promise<Creation[]> => {
   const creations = await listPublicCreations();
-  if (!creations.length) {
-    return MOCK_TRENDING_CREATIONS;
-  }
   return rankCreations(creations, null, 'trending');
 };
 


### PR DESCRIPTION
## Summary
- ensure public and trending creation actions require a configured Firestore instance instead of returning mock data
- remove mock fallbacks from the creation service so feeds fall back to empty lists rather than synthetic examples

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d820aea814832bb72a4671f6b308a2