### PR TITLE
Fix Firebase auth initialization and email flows

### DIFF
--- a/src/components/screens/login-screen.tsx
+++ b/src/components/screens/login-screen.tsx
@@ -34,6 +34,9 @@ const LoginScreen = () => {
                 } else if (error.code === 'auth/network-request-failed') {
                     description = "网络请求失败。请检查您的网络连接并确保您的应用域已在Firebase认证设置中列入白名单。";
                 }
+            } else if (error instanceof Error) {
+                description = error.message || description;
+                console.error('Unexpected email sign-up error:', error);
             } else {
                 console.error('Unexpected email sign-up error:', error);
             }
@@ -61,6 +64,9 @@ const LoginScreen = () => {
                 } else if (error.code === 'auth/network-request-failed') {
                     description = "网络请求失败。请检查您的网络连接并确保您的应用域已在Firebase认证设置中列入白名单。";
                 }
+            } else if (error instanceof Error) {
+                description = error.message || description;
+                console.error('Unexpected email sign-in error:', error);
             } else {
                 console.error('Unexpected email sign-in error:', error);
             }


### PR DESCRIPTION
## Summary
- ensure Firebase Auth is initialised via a reusable helper so the client always has an Auth instance and App Check remains optional
- update the auth context to rely on the new helper, link anonymous users on sign-up, and migrate data after email/password sign-in
- surface non-Firebase errors in the login screen toast messaging to help diagnose login failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d820823f24832ba34a355e27b20255