### PR TITLE
Add user-specific fine-tuned model support

### DIFF
--- a/src/ai/flows/generate-t-shirt-pattern-with-style.ts
+++ b/src/ai/flows/generate-t-shirt-pattern-with-style.ts
@@ -22,6 +22,10 @@ const GenerateTShirtPatternWithStyleInputSchema = z.object({
     .string()
     .optional()
     .describe('The artistic style to apply to the generated pattern.'),
+  model: z
+    .string()
+    .optional()
+    .describe('The identifier of the personalized fine-tuned model to use.'),
 });
 export type GenerateTShirtPatternWithStyleInput = z.infer<
   typeof GenerateTShirtPatternWithStyleInputSchema
@@ -76,7 +80,7 @@ IMPORTANT RULES:
     
     const {media} = await ai.generate({
       prompt: promptParts,
-      model: 'googleai/gemini-2.5-flash-image-preview',
+      model: input.model ?? 'googleai/gemini-2.5-flash-image-preview',
       config: {
         responseModalities: ['IMAGE'],
       },

--- a/src/features/creations/server/creation-service.ts
+++ b/src/features/creations/server/creation-service.ts
@@ -18,6 +18,10 @@ import { MOCK_PUBLIC_CREATIONS, MOCK_TRENDING_CREATIONS } from '@/lib/mock-data'
 import { admin, getAdminStorage } from '@/server/firebase/admin';
 import { logger } from '@/utils/logger';
 import {
+  ensureUserFineTunedModel,
+  markUserFineTunedModelAsUsed,
+} from '@/features/user-models/server/user-model-service';
+import {
   createCreation,
   deleteCreation as deleteCreationDoc,
   findCreationById,
@@ -167,13 +171,40 @@ const uploadDataUriToStorage = async (dataUri: string, userId: string): Promise<
 
 export const generatePattern = async (input: GeneratePatternInput): Promise<Creation> => {
   const { userId, prompt, style, referenceImage } = input;
+  const userModel = await ensureUserFineTunedModel(userId);
+
+  const personalizationPrompts: string[] = [];
+  const personalization = userModel.personalization;
+  if (personalization?.tags && personalization.tags.length > 0) {
+    personalizationPrompts.push(
+      `Focus on themes such as ${personalization.tags.join(', ')} that match the user's taste.`
+    );
+  }
+  if (personalization?.preferredStyles && personalization.preferredStyles.length > 0) {
+    personalizationPrompts.push(
+      `Give subtle priority to styles like ${personalization.preferredStyles.join(', ')}.`
+    );
+  }
+  if (personalization?.strength !== undefined) {
+    personalizationPrompts.push(
+      `Adjust personalization strength to ${(personalization.strength * 100).toFixed(0)}% of the base prompt.`
+    );
+  }
+
+  const generationPrompt = personalizationPrompts.length
+    ? `${prompt}. ${personalizationPrompts.join(' ')}`
+    : prompt;
+
   const payload: GenerateTShirtPatternWithStyleInput = {
-    prompt,
+    prompt: generationPrompt,
     style,
     referenceImage: referenceImage ?? undefined,
+    model: userModel.modelName,
   };
 
   const patternResult = await generateTShirtPatternWithStyle(payload);
+
+  await markUserFineTunedModelAsUsed(userId);
 
   const summary = await summarizePrompt({ prompt });
 
@@ -247,6 +278,7 @@ export const generateModel = async (
   if (!updated) {
     throw new Error('Creation not found after adding model');
   }
+  await markUserFineTunedModelAsUsed(input.userId);
   return updated;
 };
 

--- a/src/features/user-models/server/actions.ts
+++ b/src/features/user-models/server/actions.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { z } from 'zod';
+import { isFirebaseAdminConfigured } from '@/server/firebase/admin';
+import {
+  ensureUserFineTunedModel,
+  markUserFineTunedModelAsUsed,
+  updateUserFineTunedModelSettings,
+} from './user-model-service';
+
+const ensureFirestore = () => {
+  if (!isFirebaseAdminConfigured()) {
+    throw new Error('Firebase Admin SDK is not configured.');
+  }
+};
+
+const userIdSchema = z.object({
+  userId: z.string().min(1, 'userId is required'),
+});
+
+export const getUserFineTunedModelAction = async (userId: string) => {
+  ensureFirestore();
+  const { userId: parsedUserId } = userIdSchema.parse({ userId });
+  return ensureUserFineTunedModel(parsedUserId);
+};
+
+const personalizationSchema = z
+  .object({
+    strength: z.number().min(0).max(1),
+    tags: z.array(z.string()).default([]),
+    preferredStyles: z.array(z.string()).optional(),
+  })
+  .partial();
+
+const updateSchema = userIdSchema.extend({
+  modelName: z.string().optional(),
+  displayName: z.string().optional(),
+  provider: z.enum(['googleai', 'openai', 'custom']).optional(),
+  baseModel: z.string().optional(),
+  status: z.enum(['training', 'ready', 'failed']).optional(),
+  personalization: personalizationSchema.optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const updateUserFineTunedModelAction = async (
+  input: z.infer<typeof updateSchema>
+) => {
+  ensureFirestore();
+  const payload = updateSchema.parse(input);
+  return updateUserFineTunedModelSettings(payload.userId, {
+    modelName: payload.modelName,
+    displayName: payload.displayName,
+    provider: payload.provider,
+    baseModel: payload.baseModel,
+    status: payload.status,
+    personalization: payload.personalization,
+    metadata: payload.metadata,
+  });
+};
+
+export const touchUserFineTunedModelUsageAction = async (userId: string) => {
+  ensureFirestore();
+  const { userId: parsedUserId } = userIdSchema.parse({ userId });
+  return markUserFineTunedModelAsUsed(parsedUserId);
+};

--- a/src/features/user-models/server/user-model-model.ts
+++ b/src/features/user-models/server/user-model-model.ts
@@ -1,0 +1,65 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import { z } from 'zod';
+import type {
+  UserFineTunedModel,
+  UserFineTunedModelData,
+  UserFineTunedModelPersonalization,
+} from '@/lib/types';
+
+const PROVIDERS = ['googleai', 'openai', 'custom'] as const;
+const STATUSES = ['training', 'ready', 'failed'] as const;
+
+const personalizationSchema = z.object({
+  strength: z.number().min(0).max(1),
+  tags: z.array(z.string()),
+  preferredStyles: z.array(z.string()).optional(),
+});
+
+export const userFineTunedModelSchema = z.object({
+  userId: z.string(),
+  modelName: z.string(),
+  displayName: z.string(),
+  provider: z.enum(PROVIDERS),
+  baseModel: z.string(),
+  status: z.enum(STATUSES),
+  createdAt: z.instanceof(Timestamp),
+  updatedAt: z.instanceof(Timestamp),
+  lastUsedAt: z.instanceof(Timestamp).optional(),
+  personalization: personalizationSchema.optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type UserFineTunedModelDocument = z.infer<typeof userFineTunedModelSchema>;
+
+export const toUserFineTunedModel = (data: UserFineTunedModelDocument): UserFineTunedModel => ({
+  userId: data.userId,
+  modelName: data.modelName,
+  displayName: data.displayName,
+  provider: data.provider,
+  baseModel: data.baseModel,
+  status: data.status,
+  createdAt: data.createdAt.toDate().toISOString(),
+  updatedAt: data.updatedAt.toDate().toISOString(),
+  lastUsedAt: data.lastUsedAt?.toDate().toISOString(),
+  personalization: data.personalization as UserFineTunedModelPersonalization | undefined,
+  metadata: data.metadata,
+});
+
+export const toUserFineTunedModelData = (
+  model: UserFineTunedModelData | UserFineTunedModelDocument
+): UserFineTunedModelData => ({
+  userId: model.userId,
+  modelName: model.modelName,
+  displayName: model.displayName,
+  provider: model.provider,
+  baseModel: model.baseModel,
+  status: model.status,
+  createdAt: model.createdAt instanceof Timestamp ? model.createdAt : Timestamp.fromDate(new Date(model.createdAt)),
+  updatedAt: model.updatedAt instanceof Timestamp ? model.updatedAt : Timestamp.fromDate(new Date(model.updatedAt)),
+  lastUsedAt:
+    model.lastUsedAt instanceof Timestamp || model.lastUsedAt === undefined
+      ? model.lastUsedAt
+      : Timestamp.fromDate(new Date(model.lastUsedAt)),
+  personalization: model.personalization,
+  metadata: model.metadata,
+});

--- a/src/features/user-models/server/user-model-repository.ts
+++ b/src/features/user-models/server/user-model-repository.ts
@@ -1,0 +1,45 @@
+import type { DocumentSnapshot } from 'firebase-admin/firestore';
+import type { UserFineTunedModel, UserFineTunedModelData } from '@/lib/types';
+import { getDb } from '@/server/firebase/admin';
+import { toUserFineTunedModel, userFineTunedModelSchema } from './user-model-model';
+
+const COLLECTION_NAME = 'userFineTunedModels';
+
+const collectionRef = () => getDb().collection(COLLECTION_NAME);
+
+const parseDocument = (doc: DocumentSnapshot): UserFineTunedModel => {
+  const data = doc.data();
+  if (!data) {
+    throw new Error('User fine-tuned model document is empty.');
+  }
+  const parsed = userFineTunedModelSchema.parse(data);
+  return toUserFineTunedModel(parsed);
+};
+
+export const findUserFineTunedModel = async (userId: string): Promise<UserFineTunedModel | null> => {
+  const snapshot = await collectionRef().doc(userId).get();
+  if (!snapshot.exists) {
+    return null;
+  }
+  return parseDocument(snapshot);
+};
+
+export const createUserFineTunedModel = async (
+  data: UserFineTunedModelData
+): Promise<UserFineTunedModel> => {
+  await collectionRef().doc(data.userId).set(data);
+  const snapshot = await collectionRef().doc(data.userId).get();
+  return parseDocument(snapshot);
+};
+
+export const updateUserFineTunedModel = async (
+  userId: string,
+  updates: Partial<UserFineTunedModelData>
+): Promise<UserFineTunedModel> => {
+  await collectionRef().doc(userId).set(updates, { merge: true });
+  const snapshot = await collectionRef().doc(userId).get();
+  if (!snapshot.exists) {
+    throw new Error('User fine-tuned model not found after update.');
+  }
+  return parseDocument(snapshot);
+};

--- a/src/features/user-models/server/user-model-service.ts
+++ b/src/features/user-models/server/user-model-service.ts
@@ -1,0 +1,106 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import type { UserFineTunedModel, UserFineTunedModelData } from '@/lib/types';
+import {
+  createUserFineTunedModel,
+  findUserFineTunedModel,
+  updateUserFineTunedModel,
+} from './user-model-repository';
+
+const createDefaultModelData = (userId: string): UserFineTunedModelData => {
+  const now = Timestamp.fromDate(new Date());
+  const baseModel = 'googleai/gemini-2.5-flash-image-preview';
+  return {
+    userId,
+    modelName: baseModel,
+    displayName: '专属微调模型',
+    provider: 'googleai',
+    baseModel,
+    status: 'ready',
+    createdAt: now,
+    updatedAt: now,
+    lastUsedAt: now,
+    personalization: {
+      strength: 0.6,
+      tags: [],
+    },
+    metadata: {
+      initializedAutomatically: true,
+      personalizedModelPath: `users/${userId}/models/personalized`,
+    },
+  };
+};
+
+export const ensureUserFineTunedModel = async (userId: string): Promise<UserFineTunedModel> => {
+  const existing = await findUserFineTunedModel(userId);
+  if (existing) {
+    return existing;
+  }
+  const defaults = createDefaultModelData(userId);
+  return createUserFineTunedModel(defaults);
+};
+
+interface UpdateUserFineTunedModelInput {
+  modelName?: string;
+  displayName?: string;
+  provider?: UserFineTunedModelData['provider'];
+  baseModel?: string;
+  status?: UserFineTunedModelData['status'];
+  personalization?: Partial<UserFineTunedModelData['personalization']>;
+  metadata?: Record<string, unknown>;
+}
+
+export const updateUserFineTunedModelSettings = async (
+  userId: string,
+  updates: UpdateUserFineTunedModelInput
+): Promise<UserFineTunedModel> => {
+  const existing = await ensureUserFineTunedModel(userId);
+  const now = Timestamp.fromDate(new Date());
+  const partial: Partial<UserFineTunedModelData> = {
+    updatedAt: now,
+  };
+
+  if (updates.modelName) {
+    partial.modelName = updates.modelName;
+  }
+  if (updates.displayName) {
+    partial.displayName = updates.displayName;
+  }
+  if (updates.provider) {
+    partial.provider = updates.provider;
+  }
+  if (updates.baseModel) {
+    partial.baseModel = updates.baseModel;
+  }
+  if (updates.status) {
+    partial.status = updates.status;
+  }
+  if (updates.personalization) {
+    const personalization = {
+      strength:
+        updates.personalization.strength ?? existing.personalization?.strength ?? 0.6,
+      tags: updates.personalization.tags ?? existing.personalization?.tags ?? [],
+      preferredStyles:
+        updates.personalization.preferredStyles ?? existing.personalization?.preferredStyles,
+    };
+    partial.personalization = personalization;
+  }
+  if (updates.metadata) {
+    partial.metadata = {
+      ...(existing.metadata ?? {}),
+      ...updates.metadata,
+    };
+  }
+
+  return updateUserFineTunedModel(userId, partial);
+};
+
+export const markUserFineTunedModelAsUsed = async (
+  userId: string
+): Promise<UserFineTunedModel> => {
+  await ensureUserFineTunedModel(userId);
+  const now = Timestamp.fromDate(new Date());
+  return updateUserFineTunedModel(userId, {
+    lastUsedAt: now,
+    updatedAt: now,
+  });
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,44 @@ export interface Model {
 }
 
 
+export type UserFineTunedModelStatus = 'training' | 'ready' | 'failed';
+export type UserFineTunedModelProvider = 'googleai' | 'openai' | 'custom';
+
+export interface UserFineTunedModelPersonalization {
+    strength: number;
+    tags: string[];
+    preferredStyles?: string[];
+}
+
+export interface UserFineTunedModel {
+    userId: string;
+    modelName: string;
+    displayName: string;
+    provider: UserFineTunedModelProvider;
+    baseModel: string;
+    status: UserFineTunedModelStatus;
+    createdAt: string;
+    updatedAt: string;
+    lastUsedAt?: string;
+    personalization?: UserFineTunedModelPersonalization;
+    metadata?: Record<string, unknown>;
+}
+
+export interface UserFineTunedModelData {
+    userId: string;
+    modelName: string;
+    displayName: string;
+    provider: UserFineTunedModelProvider;
+    baseModel: string;
+    status: UserFineTunedModelStatus;
+    createdAt: Timestamp;
+    updatedAt: Timestamp;
+    lastUsedAt?: Timestamp;
+    personalization?: UserFineTunedModelPersonalization;
+    metadata?: Record<string, unknown>;
+}
+
+
 // This is the object shape that the client-side components will receive.
 // Note that 'createdAt' is a string because Timestamp objects are not serializable across server/client boundaries.
 export interface Creation {

--- a/src/server/actions/index.ts
+++ b/src/server/actions/index.ts
@@ -1,3 +1,4 @@
 export * from '@/features/creations/server/actions';
 export * from '@/features/orders/server/actions';
 export * from '@/features/auth/server/actions';
+export * from '@/features/user-models/server/actions';


### PR DESCRIPTION
## Summary
- add a Firestore-backed service and server actions to manage per-user fine-tuned model metadata
- update pattern generation to use each user's personalized model preferences and record usage
- expose the new actions through the server action index and allow flows to accept a custom model id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d821a4f298832bbd8efa92cc4e9544